### PR TITLE
Should we support ES256 DSA?

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Each SDK will **publish** example usage for _each_ implemented feature. This can
 | Algorithm       | Typescript | Kotlin | Rust | Swift |
 | --------------- | ---------- | ------ | ---- | ----- |
 | `ES256K`        | ✅          | ✅      | ❌    | ❌     |
+| `ES256`         | ❌          | ❌      | ❌    | ❌     |
 | `EdDSA:Ed25519` | ✅          | ✅      | ❌    | ❌     |
 
 


### PR DESCRIPTION
In the [previous requirements doc](https://hackmd.io/@tbdocs/sdk-requirements#Key-Generation), there was a stretch goal of supporting `secp256r1`. 

This may be a misunderstanding on my part, but I _believe_ that ES256K is only used for `secp256k1`. Wondering if we should be tracking support for the other, or if that's no longer a goal