### PR TITLE
portable did metadata could be optional.

### DIFF
--- a/test-vectors/portable_did/parse.json
+++ b/test-vectors/portable_did/parse.json
@@ -161,7 +161,7 @@
           ]
         }
       },
-      "errors": true
+      "errors": false
     }
   ]
 }


### PR DESCRIPTION
PortableDid in web5-js is optional
PortableDid in web5-kt is NOT optional
PortableDid in web5-swift is optional

KT version might require update?
