### PR TITLE
removing invalid test

### DIFF
--- a/test-vectors/crypto_ed25519/verify.json
+++ b/test-vectors/crypto_ed25519/verify.json
@@ -105,21 +105,6 @@
       },
       "output": false,
       "errors": false
-    },
-    {
-      "description": "error when given a private key",
-      "input": {
-        "data": "",
-        "key": {
-          "crv": "Ed25519",
-          "d": "nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A",
-          "kid": "kPrK_qmxVWaYVA9wwBF6Iuo3vVzz7TxHCTwXBygrS4k",
-          "kty": "OKP",
-          "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
-        },
-        "signature": "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b"
-      },
-      "errors": true
     }
   ]
 }


### PR DESCRIPTION


Removing a test that does not make sense. It should not necessarily throw an error if it is a private key, this is an implementation issue.